### PR TITLE
`Development`: Add health indicator api

### DIFF
--- a/common/src/main/java/de/tum/cit/artemis/push/common/SendService.java
+++ b/common/src/main/java/de/tum/cit/artemis/push/common/SendService.java
@@ -5,4 +5,6 @@ import org.springframework.http.ResponseEntity;
 public interface SendService<T> {
 
     ResponseEntity<Void> send(T request);
+
+    boolean isHealthy();
 }

--- a/hermes/build.gradle
+++ b/hermes/build.gradle
@@ -27,3 +27,7 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+springBoot {
+    buildInfo()
+}

--- a/hermes/src/main/java/de/tum/cit/artemis/push/HealthController.java
+++ b/hermes/src/main/java/de/tum/cit/artemis/push/HealthController.java
@@ -1,0 +1,20 @@
+package de.tum.cit.artemis.push;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class HealthController {
+    private final NotificationHealthService healthService;
+
+    public HealthController(NotificationHealthService healthService) {
+        this.healthService = healthService;
+    }
+
+    @GetMapping("/health")
+    public HealthReport getHealth() {
+        return healthService.getHealthReport();
+    }
+}

--- a/hermes/src/main/java/de/tum/cit/artemis/push/HealthReport.java
+++ b/hermes/src/main/java/de/tum/cit/artemis/push/HealthReport.java
@@ -1,25 +1,4 @@
 package de.tum.cit.artemis.push;
 
-public class HealthReport {
-    private final boolean isApnsConnected;
-    private final boolean isFirebaseConnected;
-    private final String versionNumber;
-
-    public HealthReport(boolean isApnsConnected, boolean isFirebaseConnected, String versionNumber) {
-        this.isApnsConnected = isApnsConnected;
-        this.isFirebaseConnected = isFirebaseConnected;
-        this.versionNumber = versionNumber;
-    }
-
-    public boolean isApnsConnected() {
-        return isApnsConnected;
-    }
-
-    public boolean isFirebaseConnected() {
-        return isFirebaseConnected;
-    }
-
-    public String getVersionNumber() {
-        return versionNumber;
-    }
+public record HealthReport(boolean isApnsConnected, boolean isFirebaseConnected, String versionNumber) {
 }

--- a/hermes/src/main/java/de/tum/cit/artemis/push/HealthReport.java
+++ b/hermes/src/main/java/de/tum/cit/artemis/push/HealthReport.java
@@ -1,0 +1,25 @@
+package de.tum.cit.artemis.push;
+
+public class HealthReport {
+    private final boolean isApnsConnected;
+    private final boolean isFirebaseConnected;
+    private final String versionNumber;
+
+    public HealthReport(boolean isApnsConnected, boolean isFirebaseConnected, String versionNumber) {
+        this.isApnsConnected = isApnsConnected;
+        this.isFirebaseConnected = isFirebaseConnected;
+        this.versionNumber = versionNumber;
+    }
+
+    public boolean isApnsConnected() {
+        return isApnsConnected;
+    }
+
+    public boolean isFirebaseConnected() {
+        return isFirebaseConnected;
+    }
+
+    public String getVersionNumber() {
+        return versionNumber;
+    }
+}

--- a/hermes/src/main/java/de/tum/cit/artemis/push/NotificationHealthService.java
+++ b/hermes/src/main/java/de/tum/cit/artemis/push/NotificationHealthService.java
@@ -1,0 +1,23 @@
+package de.tum.cit.artemis.push;
+
+import de.tum.cit.artemis.push.apns.ApnsSendService;
+import de.tum.cit.artemis.push.firebase.FirebaseSendService;
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.stereotype.Service;
+
+@Service
+public class NotificationHealthService {
+    private final FirebaseSendService firebaseSendService;
+    private final ApnsSendService apnsSendService;
+    private final BuildProperties buildProperties;
+
+    NotificationHealthService(FirebaseSendService firebaseSendService, ApnsSendService apnsSendService, BuildProperties buildProperties) {
+        this.firebaseSendService = firebaseSendService;
+        this.apnsSendService = apnsSendService;
+        this.buildProperties = buildProperties;
+    }
+
+    public HealthReport getHealthReport() {
+        return new HealthReport(apnsSendService.isHealthy(), firebaseSendService.isHealthy(), buildProperties.getVersion());
+    }
+}


### PR DESCRIPTION
Currently, artemis checks if hermes is running by calling the base url and looking if it returns a 200 response code. While working, this does not provide a lot of information to the admins.

This change implements a new api `/api/health` that returns whether or not the Hermes service is able to connect to APNS and Firebase and returns the version number of the Hermes instance.