### PR TITLE
Bound async send and report honest health

### DIFF
--- a/apns/src/main/java/de/tum/cit/artemis/push/apns/ApnsCertificateInspector.java
+++ b/apns/src/main/java/de/tum/cit/artemis/push/apns/ApnsCertificateInspector.java
@@ -1,0 +1,67 @@
+package de.tum.cit.artemis.push.apns;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.time.Instant;
+import java.util.Enumeration;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Reads the expiry date of the APNs client certificate (a PKCS#12 keystore) so that the relay can report an
+ * expired certificate proactively — before the first send fails — and detect an expiry that occurs while the
+ * process keeps running. This is pure file I/O and never touches the network, so it can never block or starve
+ * the health endpoint.
+ */
+public class ApnsCertificateInspector {
+
+    private static final Logger log = LoggerFactory.getLogger(ApnsCertificateInspector.class);
+
+    /**
+     * Reads the keystore and returns the earliest {@code notAfter} across all certificates it contains. The
+     * earliest is used so a chain with one already-expired certificate is reported as expired.
+     *
+     * @param keystorePath     the path to the PKCS#12 keystore (the APNs certificate)
+     * @param keystorePassword the keystore password
+     * @return the earliest expiry instant, or empty if the keystore is missing/unreadable or has no certificate
+     */
+    public Optional<Instant> earliestExpiry(String keystorePath, String keystorePassword) {
+        if (keystorePath == null || keystorePassword == null) {
+            return Optional.empty();
+        }
+        try (InputStream in = new FileInputStream(keystorePath)) {
+            KeyStore keyStore = KeyStore.getInstance("PKCS12");
+            keyStore.load(in, keystorePassword.toCharArray());
+            Instant earliest = null;
+            Enumeration<String> aliases = keyStore.aliases();
+            while (aliases.hasMoreElements()) {
+                Certificate certificate = keyStore.getCertificate(aliases.nextElement());
+                if (certificate instanceof X509Certificate x509Certificate) {
+                    Instant notAfter = x509Certificate.getNotAfter().toInstant();
+                    if (earliest == null || notAfter.isBefore(earliest)) {
+                        earliest = notAfter;
+                    }
+                }
+            }
+            return Optional.ofNullable(earliest);
+        }
+        catch (IOException | GeneralSecurityException e) {
+            log.warn("Could not read APNs certificate expiry from {}", keystorePath, e);
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * @return true if the certificate is expired, i.e. {@code expiry} is at or before {@code now}
+     */
+    public static boolean isExpired(Instant expiry, Instant now) {
+        return !expiry.isAfter(now);
+    }
+}

--- a/apns/src/main/java/de/tum/cit/artemis/push/apns/ApnsSendService.java
+++ b/apns/src/main/java/de/tum/cit/artemis/push/apns/ApnsSendService.java
@@ -4,9 +4,11 @@ import com.eatthepath.pushy.apns.*;
 import com.eatthepath.pushy.apns.util.SimpleApnsPayloadBuilder;
 import com.eatthepath.pushy.apns.util.SimpleApnsPushNotification;
 import com.eatthepath.pushy.apns.util.concurrent.PushNotificationFuture;
+import de.tum.cit.artemis.push.common.BoundedSendExecutor;
 import de.tum.cit.artemis.push.common.NotificationRequest;
 import de.tum.cit.artemis.push.common.PushNotificationApiType;
 import de.tum.cit.artemis.push.common.SendService;
+import jakarta.annotation.PreDestroy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -15,18 +17,42 @@ import org.springframework.context.event.EventListener;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.context.request.async.DeferredResult;
 
 import java.io.File;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
+/**
+ * Relays push notifications to Apple Push Notification service (APNs) via the pushy library.
+ *
+ * <p>Sends run on a {@link BoundedSendExecutor} (a fixed worker pool + bounded queue), never on the Tomcat
+ * request thread, so an unreachable APNs (most importantly: an expired client certificate) can never exhaust the
+ * servlet thread pool and starve the health endpoint.
+ *
+ * <p>Health contract: the relay is healthy when it is <em>configured</em> (the certificate loaded successfully),
+ * the loaded certificate is <em>not past its expiry</em>, and the most recent send (if any) did not reveal a
+ * provider/credential problem. Reading health never performs I/O — the certificate expiry is captured once at
+ * startup and compared in memory — so it cannot be starved by a provider outage.
+ */
 @Service
 public class ApnsSendService implements SendService<NotificationRequest> {
 
     private static final Logger log = LoggerFactory.getLogger(ApnsSendService.class);
+
+    /**
+     * APNs reason strings (the wire values returned by {@link PushNotificationResponse#getRejectionReason()}) that
+     * indicate OUR certificate/credentials are broken, i.e. every send will fail until it is fixed. Receiving one of
+     * these — or, far more commonly, a TLS/connection exception — flips the relay to unhealthy. Every other rejection
+     * reason (bad/unregistered device token, payload too large, rate limiting, ...) means APNs was reachable and
+     * rejected this one notification, so those keep the relay healthy. The values are Apple's documented reason
+     * phrases (which {@code getRejectionReason()} returns verbatim).
+     */
+    private static final Set<String> CREDENTIAL_REJECTION_REASONS = Set.of("BadCertificate", "BadCertificateEnvironment", "Forbidden", "ExpiredProviderToken",
+            "InvalidProviderToken", "MissingProviderToken");
 
     @Value("${APNS_CERTIFICATE_PATH: #{null}}")
     private String apnsCertificatePath;
@@ -48,17 +74,41 @@ public class ApnsSendService implements SendService<NotificationRequest> {
     @Value("${APNS_TRUSTED_CERT_PATH:#{null}}")
     private String apnsTrustedCertPath;
 
+    @Value("${apns.workers:50}")
+    private int workers;
+
+    @Value("${apns.queue-capacity:2000}")
+    private int queueCapacity;
+
+    @Value("${apns.response-timeout-ms:30000}")
+    private long responseTimeoutMs;
+
+    @Value("${apns.connection-timeout-ms:2000}")
+    private long connectionTimeoutMs;
+
+    private final ApnsCertificateInspector certificateInspector = new ApnsCertificateInspector();
+
     private ApnsClient apnsClient;
 
-    private boolean isConnected;
-    
+    private volatile boolean isConnected;
+
+    /**
+     * The earliest expiry of the certificate that the {@link ApnsClient} actually loaded, captured once at startup.
+     * {@code null} if it could not be determined. Reading {@link #isHealthy()} compares this against the clock in
+     * memory, so an expired certificate is reported immediately (no polling lag) and runtime file rotation cannot
+     * mask the fact that pushy still holds the originally-loaded certificate.
+     */
+    private volatile Instant loadedCertificateExpiry;
+
+    private BoundedSendExecutor dispatcher;
+
     @EventListener(ApplicationReadyEvent.class)
     public void applicationReady() {
-        log.info("apnsCertificatePwd: {}", apnsCertificatePwd);
-        log.info("apnsCertificatePath: {}", apnsCertificatePath);
-        log.info("apnsProdEnvironment: {}", apnsProdEnvironment);
+        dispatcher = new BoundedSendExecutor("apns", workers, queueCapacity, responseTimeoutMs);
+
         if (apnsCertificatePwd == null || apnsCertificatePath == null || apnsProdEnvironment == null) {
             log.error("Could not init APNS service. Certificate information missing.");
+            isConnected = false;
             return;
         }
         try {
@@ -66,27 +116,60 @@ public class ApnsSendService implements SendService<NotificationRequest> {
                     : (apnsProdEnvironment ? ApnsClientBuilder.PRODUCTION_APNS_HOST : ApnsClientBuilder.DEVELOPMENT_APNS_HOST);
             ApnsClientBuilder clientBuilder = new ApnsClientBuilder()
                     .setApnsServer(apnsHost, apnsServerPort)
-                    .setClientCredentials(new File(apnsCertificatePath), apnsCertificatePwd);
+                    .setClientCredentials(new File(apnsCertificatePath), apnsCertificatePwd)
+                    .setConnectionTimeout(Duration.ofMillis(connectionTimeoutMs));
             if (apnsTrustedCertPath != null) {
                 clientBuilder.setTrustedServerCertificateChain(new File(apnsTrustedCertPath));
             }
             apnsClient = clientBuilder.build();
             isConnected = true;
-            log.info("Started APNS client successfully!");
+            log.info("Started APNS client successfully (environment: {})", apnsProdEnvironment ? "production" : "development");
         } catch (IOException e) {
             isConnected = false;
             log.error("Could not init APNS service", e);
         }
+
+        // Report an already-expired certificate immediately, before the first send is ever attempted.
+        captureLoadedCertificateExpiry();
     }
 
     @Override
-    public ResponseEntity<Void> send(NotificationRequest request) {
-        return sendApnsRequest(request);
+    public DeferredResult<ResponseEntity<Void>> send(NotificationRequest request) {
+        if (dispatcher == null) {
+            // Should not happen once the application is ready, but stay defensive rather than NPE.
+            return completed(ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).build());
+        }
+        return dispatcher.submit(() -> doSend(request));
     }
 
-    // TODO: either we send this async (in a separate bean), but then we cannot return the response entity, or we send it sync and block the thread (as we do it now)
-    // @Async
-    private ResponseEntity<Void> sendApnsRequest(NotificationRequest request) {
+    // visible for testing — performs the blocking send on a worker thread and maps the outcome to an HTTP response
+    ResponseEntity<Void> doSend(NotificationRequest request) {
+        if (apnsClient == null) {
+            isConnected = false;
+            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).build();
+        }
+
+        SimpleApnsPushNotification notification = buildNotification(request);
+
+        PushNotificationFuture<SimpleApnsPushNotification, PushNotificationResponse<SimpleApnsPushNotification>> responseFuture = apnsClient.sendNotification(notification);
+        try {
+            PushNotificationResponse<SimpleApnsPushNotification> response = responseFuture.get();
+            return handleResponse(response, request.token());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            isConnected = false;
+            log.error("Interrupted while sending push notification.", e);
+            return ResponseEntity.status(HttpStatus.EXPECTATION_FAILED).build();
+        } catch (ExecutionException e) {
+            // The send never reached APNs — a TLS handshake / connection failure, which is exactly what an expired
+            // client certificate produces. Treat as "provider unreachable" so health honestly reports the outage.
+            isConnected = false;
+            log.error("Failed to send push notification (provider unreachable).", e);
+            return ResponseEntity.status(HttpStatus.EXPECTATION_FAILED).build();
+        }
+    }
+
+    private SimpleApnsPushNotification buildNotification(NotificationRequest request) {
         var payload = new SimpleApnsPayloadBuilder()
                 .addCustomProperty("iv", request.initializationVector())
                 .addCustomProperty("payload", request.payloadCipherText());
@@ -94,48 +177,79 @@ public class ApnsSendService implements SendService<NotificationRequest> {
         var isV2Api = request.apiType() == PushNotificationApiType.IOS_V2;
 
         if (isV2Api) {
-           payload.setMutableContent(true);
-           // Alert Body is a fallback in case we cannot decrypt the payload
-           payload.setAlertBody("There is a new notification in Artemis.");
+            payload.setMutableContent(true);
+            // Alert Body is a fallback in case we cannot decrypt the payload
+            payload.setAlertBody("There is a new notification in Artemis.");
         } else {
             payload.setContentAvailable(true);
         }
 
-        var playloadString = payload.build();
-
-        SimpleApnsPushNotification notification = new SimpleApnsPushNotification(request.token(),
+        return new SimpleApnsPushNotification(request.token(),
                 "de.tum.cit.ase.artemis",
-                playloadString,
+                payload.build(),
                 Instant.now().plus(Duration.ofDays(7)),
                 DeliveryPriority.getFromCode(5),
                 isV2Api ? PushType.ALERT : PushType.BACKGROUND);
+    }
 
-        PushNotificationFuture<SimpleApnsPushNotification, PushNotificationResponse<SimpleApnsPushNotification>> responsePushNotificationFuture = apnsClient.sendNotification(notification);
-        try {
-            final PushNotificationResponse<SimpleApnsPushNotification> pushNotificationResponse = responsePushNotificationFuture.get();
-            if (pushNotificationResponse.isAccepted()) {
-                log.info("Send notification to {}", request.token());
-                isConnected = true;
-                return ResponseEntity.ok().build();
-            } else {
-                // APNS reports rejection reasons using Apple's documented phrases (e.g. "BadCertificate"),
-                // which is exactly what getRejectionReason() returns -- not the RejectionReason enum name.
-                var certificateRejectionReasons = List.of("BadCertificate", "BadCertificateEnvironment");
-                if (pushNotificationResponse.getRejectionReason().isPresent() && certificateRejectionReasons.contains(pushNotificationResponse.getRejectionReason().get())) {
-                    isConnected = false;
-                }
-                log.error("Notification rejected by the APNs gateway: {}", pushNotificationResponse.getRejectionReason());
-                pushNotificationResponse.getTokenInvalidationTimestamp().ifPresent(timestamp -> log.error("\t... and the token is invalid as of {}", timestamp));
-                return ResponseEntity.status(HttpStatus.EXPECTATION_FAILED).build();
-            }
-        } catch (ExecutionException | InterruptedException e) {
-            log.error("Failed to send push notification.", e);
-            return ResponseEntity.status(HttpStatus.EXPECTATION_FAILED).build();
+    private ResponseEntity<Void> handleResponse(PushNotificationResponse<SimpleApnsPushNotification> response, String token) {
+        if (response.isAccepted()) {
+            // A successful send proves the connection (and thus the certificate) works.
+            isConnected = true;
+            log.info("Send notification to {}", token);
+            return ResponseEntity.ok().build();
         }
+        String reason = response.getRejectionReason().orElse("unknown");
+        if (CREDENTIAL_REJECTION_REASONS.contains(reason)) {
+            // Our certificate/credentials are broken — every send will fail until this is fixed.
+            isConnected = false;
+            log.error("Notification rejected by the APNs gateway due to a credential/configuration problem: {}", reason);
+        } else {
+            // APNs was reachable and rejected this single notification (e.g. bad/unregistered token). Stay healthy.
+            isConnected = true;
+            log.warn("Notification rejected by the APNs gateway for token {}: {}", token, reason);
+        }
+        response.getTokenInvalidationTimestamp().ifPresent(timestamp -> log.warn("\t... and the token is invalid as of {}", timestamp));
+        return ResponseEntity.status(HttpStatus.EXPECTATION_FAILED).build();
+    }
+
+    private void captureLoadedCertificateExpiry() {
+        loadedCertificateExpiry = certificateInspector.earliestExpiry(apnsCertificatePath, apnsCertificatePwd).orElse(null);
+        if (loadedCertificateExpiry == null) {
+            log.warn("Could not determine the APNs certificate expiry; health will rely on send outcomes only");
+        } else if (ApnsCertificateInspector.isExpired(loadedCertificateExpiry, Instant.now())) {
+            log.error("APNs certificate is EXPIRED (expired at {}); APNs is reported unhealthy until a valid certificate is deployed", loadedCertificateExpiry);
+        } else {
+            log.info("APNs certificate is valid until {}", loadedCertificateExpiry);
+        }
+    }
+
+    private boolean isLoadedCertificateExpired() {
+        Instant expiry = loadedCertificateExpiry;
+        return expiry != null && ApnsCertificateInspector.isExpired(expiry, Instant.now());
     }
 
     @Override
     public boolean isHealthy() {
-        return isConnected;
+        // ANDing with the certificate expiry means that even a previously-successful send (isConnected == true)
+        // cannot make the relay report healthy once the loaded certificate is past its expiry. This is computed in
+        // memory on every read, so it is honest at the exact expiry instant without any background polling.
+        return isConnected && !isLoadedCertificateExpired();
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        if (dispatcher != null) {
+            dispatcher.shutdown();
+        }
+        if (apnsClient != null) {
+            apnsClient.close();
+        }
+    }
+
+    private static DeferredResult<ResponseEntity<Void>> completed(ResponseEntity<Void> response) {
+        DeferredResult<ResponseEntity<Void>> deferred = new DeferredResult<>();
+        deferred.setResult(response);
+        return deferred;
     }
 }

--- a/apns/src/test/java/de/tum/cit/artemis/push/apns/ApnsCertificateInspectorTest.java
+++ b/apns/src/test/java/de/tum/cit/artemis/push/apns/ApnsCertificateInspectorTest.java
@@ -1,0 +1,42 @@
+package de.tum.cit.artemis.push.apns;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import org.junit.jupiter.api.Test;
+
+class ApnsCertificateInspectorTest {
+
+    private final ApnsCertificateInspector inspector = new ApnsCertificateInspector();
+
+    @Test
+    void isExpiredWhenExpiryIsInThePast() {
+        Instant now = Instant.parse("2026-06-18T00:00:00Z");
+        assertThat(ApnsCertificateInspector.isExpired(now.minus(1, ChronoUnit.DAYS), now)).isTrue();
+    }
+
+    @Test
+    void isExpiredWhenExpiryEqualsNow() {
+        Instant now = Instant.parse("2026-06-18T00:00:00Z");
+        assertThat(ApnsCertificateInspector.isExpired(now, now)).isTrue();
+    }
+
+    @Test
+    void isNotExpiredWhenExpiryIsInTheFuture() {
+        Instant now = Instant.parse("2026-06-18T00:00:00Z");
+        assertThat(ApnsCertificateInspector.isExpired(now.plus(1, ChronoUnit.DAYS), now)).isFalse();
+    }
+
+    @Test
+    void earliestExpiryIsEmptyForNullArguments() {
+        assertThat(inspector.earliestExpiry(null, "pwd")).isEmpty();
+        assertThat(inspector.earliestExpiry("/some/path.p12", null)).isEmpty();
+    }
+
+    @Test
+    void earliestExpiryIsEmptyForMissingFile() {
+        assertThat(inspector.earliestExpiry("/nonexistent/definitely-not-here.p12", "pwd")).isEmpty();
+    }
+}

--- a/apns/src/test/java/de/tum/cit/artemis/push/apns/ApnsSendServiceTest.java
+++ b/apns/src/test/java/de/tum/cit/artemis/push/apns/ApnsSendServiceTest.java
@@ -30,6 +30,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -97,9 +99,18 @@ class ApnsSendServiceTest {
         ReflectionTestUtils.setField(service, "apnsServerHost", "localhost");
         ReflectionTestUtils.setField(service, "apnsServerPort", port);
         ReflectionTestUtils.setField(service, "apnsTrustedCertPath", serverCertificate.certificate().getAbsolutePath());
+        applyExecutorConfig(service);
 
         service.applicationReady();
         assertThat(service.isHealthy()).as("client should initialise successfully").isTrue();
+    }
+
+    /** Supplies the bounded-executor settings that Spring would normally inject from @Value defaults. */
+    private static void applyExecutorConfig(ApnsSendService service) {
+        ReflectionTestUtils.setField(service, "workers", 4);
+        ReflectionTestUtils.setField(service, "queueCapacity", 100);
+        ReflectionTestUtils.setField(service, "responseTimeoutMs", 30_000L);
+        ReflectionTestUtils.setField(service, "connectionTimeoutMs", 2_000L);
     }
 
     /** Packages the generated client certificate and key into a temporary PKCS#12 keystore. */
@@ -128,7 +139,7 @@ class ApnsSendServiceTest {
     void sendsV2NotificationAsAlertWithEncryptedPayload() {
         NotificationRequest request = new NotificationRequest("iv-123", "cipher-abc", "device-token-1", PushNotificationApiType.IOS_V2);
 
-        ResponseEntity<Void> response = service.send(request);
+        ResponseEntity<Void> response = service.doSend(request);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(service.isHealthy()).isTrue();
@@ -145,7 +156,7 @@ class ApnsSendServiceTest {
     void sendsDefaultNotificationAsBackgroundContentAvailable() {
         NotificationRequest request = new NotificationRequest("iv-9", "cipher-9", "device-token-2", PushNotificationApiType.DEFAULT);
 
-        ResponseEntity<Void> response = service.send(request);
+        ResponseEntity<Void> response = service.doSend(request);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(header("apns-push-type")).isEqualToIgnoringCase("background");
@@ -159,7 +170,7 @@ class ApnsSendServiceTest {
     void rejectedNotificationReturnsExpectationFailedButStaysHealthy() {
         handlerFactory.rejectWith = RejectionReason.BAD_DEVICE_TOKEN;
 
-        ResponseEntity<Void> response = service.send(new NotificationRequest("iv", "p", "bad-token", PushNotificationApiType.IOS_V2));
+        ResponseEntity<Void> response = service.doSend(new NotificationRequest("iv", "p", "bad-token", PushNotificationApiType.IOS_V2));
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.EXPECTATION_FAILED);
         // A bad device token is not a certificate problem, so the gateway is still considered healthy.
@@ -170,10 +181,54 @@ class ApnsSendServiceTest {
     void badCertificateEnvironmentRejectionMarksServiceUnhealthy() {
         handlerFactory.rejectWith = RejectionReason.BAD_CERTIFICATE_ENVIRONMENT;
 
-        ResponseEntity<Void> response = service.send(new NotificationRequest("iv", "p", "token", PushNotificationApiType.IOS_V2));
+        ResponseEntity<Void> response = service.doSend(new NotificationRequest("iv", "p", "token", PushNotificationApiType.IOS_V2));
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.EXPECTATION_FAILED);
         assertThat(service.isHealthy()).as("a certificate/environment rejection must flag the gateway as unhealthy").isFalse();
+    }
+
+    @Test
+    void reportsUnhealthyOnceTheLoadedCertificateIsExpired() {
+        // The service initialised healthy against a valid certificate ...
+        assertThat(service.isHealthy()).isTrue();
+
+        // ... but the moment the loaded certificate is past its expiry, health must report unhealthy immediately,
+        // even without any failing send (this is the proactive expired-certificate detection).
+        ReflectionTestUtils.setField(service, "loadedCertificateExpiry", Instant.now().minus(1, ChronoUnit.MINUTES));
+
+        assertThat(service.isHealthy()).isFalse();
+    }
+
+    @Test
+    void handshakeFailureMarksServiceUnhealthy() throws Exception {
+        // An expired/invalid client certificate fails the TLS handshake, which pushy surfaces as an
+        // ExecutionException on the send. We reproduce a handshake failure deterministically by pointing a fresh
+        // service at the real mock server but trusting the WRONG server certificate, so the TLS handshake is
+        // rejected. The send must fail and flip health to unhealthy (the bug the original code missed: it only
+        // checked rejection reasons and never the handshake/connection failure path).
+        ApnsSendService failing = new ApnsSendService();
+        ReflectionTestUtils.setField(failing, "apnsCertificatePath", clientKeyStoreFile.getAbsolutePath());
+        ReflectionTestUtils.setField(failing, "apnsCertificatePwd", P12_PASSWORD);
+        ReflectionTestUtils.setField(failing, "apnsProdEnvironment", false);
+        ReflectionTestUtils.setField(failing, "apnsServerHost", "localhost");
+        ReflectionTestUtils.setField(failing, "apnsServerPort", port);
+        // Trust the client's own certificate instead of the server's — the server's certificate will not be trusted.
+        ReflectionTestUtils.setField(failing, "apnsTrustedCertPath", clientCertificate.certificate().getAbsolutePath());
+        applyExecutorConfig(failing);
+        failing.applicationReady();
+
+        try {
+            ResponseEntity<Void> response = failing.doSend(new NotificationRequest("iv", "p", "token", PushNotificationApiType.IOS_V2));
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.EXPECTATION_FAILED);
+            assertThat(failing.isHealthy()).as("a connection/handshake failure must flag the gateway as unhealthy").isFalse();
+        }
+        finally {
+            Object client = ReflectionTestUtils.getField(failing, "apnsClient");
+            if (client instanceof ApnsClient apnsClient) {
+                apnsClient.close();
+            }
+        }
     }
 
     private static String header(String name) {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -18,6 +18,8 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
 tasks.named('test') {

--- a/common/src/main/java/de/tum/cit/artemis/push/common/BoundedSendExecutor.java
+++ b/common/src/main/java/de/tum/cit/artemis/push/common/BoundedSendExecutor.java
@@ -1,0 +1,154 @@
+package de.tum.cit.artemis.push.common;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.context.request.async.DeferredResult;
+
+/**
+ * A small, self-contained async dispatcher that bounds how much push-notification work can be in flight or
+ * queued at any moment. It is the core of the relay's backpressure strategy.
+ *
+ * <p>Why this exists: the original relay ran the blocking provider call ({@code apnsClient.sendNotification().get()})
+ * directly on the Tomcat request thread. When the provider was unreachable (e.g. an expired APNs certificate),
+ * every request thread blocked and the health endpoint — also served by a Tomcat thread — could no longer be
+ * answered, so the whole service appeared dead. This dispatcher fixes that by:
+ * <ul>
+ *     <li>running the blocking provider call on a <b>fixed</b> worker pool (never on the Tomcat thread), and</li>
+ *     <li>bounding the backlog with an {@link ArrayBlockingQueue}: once {@code workers + queueCapacity} requests
+ *         are outstanding, further submissions are rejected immediately with {@code 503}.</li>
+ * </ul>
+ *
+ * <p>Because a worker never starts a second provider call before its first one returns, the number of concurrent
+ * provider calls is bounded by the worker count. This is what keeps the provider library's own internal queues
+ * (e.g. pushy's unbounded {@code pendingAcquisitionPromises}) bounded without any extra machinery — no circuit
+ * breaker, no semaphores, no client rebuild are required for the stated goals.
+ */
+public class BoundedSendExecutor {
+
+    private static final Logger log = LoggerFactory.getLogger(BoundedSendExecutor.class);
+
+    private static final ResponseEntity<Void> SERVICE_UNAVAILABLE = ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).build();
+
+    private static final ResponseEntity<Void> INTERNAL_SERVER_ERROR = ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+
+    private final String name;
+
+    private final long responseTimeoutMillis;
+
+    private final ThreadPoolExecutor executor;
+
+    /**
+     * @param name                  a short name used for thread names and log messages (e.g. "apns")
+     * @param workers               the fixed number of worker threads (== max concurrent provider calls)
+     * @param queueCapacity         the maximum number of requests that may wait for a free worker before new
+     *                              requests are rejected with {@code 503}
+     * @param responseTimeoutMillis how long the HTTP connection is held open before the deferred result completes
+     *                              with {@code 503}; the worker is not interrupted and simply finds the result
+     *                              already completed when it eventually runs
+     */
+    public BoundedSendExecutor(String name, int workers, int queueCapacity, long responseTimeoutMillis) {
+        if (workers < 1) {
+            throw new IllegalArgumentException("workers must be >= 1, was " + workers);
+        }
+        if (queueCapacity < 1) {
+            throw new IllegalArgumentException("queueCapacity must be >= 1, was " + queueCapacity);
+        }
+        this.name = name;
+        this.responseTimeoutMillis = responseTimeoutMillis;
+        // core == max so all threads are long-lived and the bounded queue (not extra threads) absorbs bursts;
+        // when both the workers and the queue are saturated, AbortPolicy throws RejectedExecutionException.
+        this.executor = new ThreadPoolExecutor(workers, workers, 0L, TimeUnit.MILLISECONDS, new ArrayBlockingQueue<>(queueCapacity), namedThreadFactory(name),
+                new ThreadPoolExecutor.AbortPolicy());
+    }
+
+    /**
+     * Submits a blocking send task to the worker pool and returns a {@link DeferredResult} that completes with
+     * the task's response.
+     *
+     * <ul>
+     *     <li>If the queue is full, the task is rejected and the result completes immediately with {@code 503}.
+     *         The upstream caller (Artemis) retries non-2xx with backoff, so this is backpressure, not data loss.</li>
+     *     <li>If the safety timeout fires before the worker runs, the result completes with {@code 503}. The worker
+     *         then sees {@link DeferredResult#isSetOrExpired()} and skips the provider call, avoiding a send after
+     *         the client already received a (timeout) response — which would otherwise risk a duplicate notification.</li>
+     * </ul>
+     *
+     * @param task the blocking work to perform on a worker thread; must return the HTTP response to relay back
+     * @return the deferred HTTP response
+     */
+    public DeferredResult<ResponseEntity<Void>> submit(Supplier<ResponseEntity<Void>> task) {
+        DeferredResult<ResponseEntity<Void>> deferred = new DeferredResult<>(responseTimeoutMillis, () -> SERVICE_UNAVAILABLE);
+        try {
+            executor.execute(() -> {
+                // The HTTP response may already have been completed by the safety timeout while this task waited
+                // in the queue. Do not contact the provider in that case: the client is gone and a late send could
+                // duplicate a notification that the caller already retried. This guards the common case (the task
+                // sat in the queue past the deadline). It does NOT cover the residual race where the timeout fires
+                // after this check but during the provider send already in progress — in that rare case the caller
+                // gets 503, may retry, and the in-flight send can still succeed, producing a duplicate notification.
+                // That is an accepted trade-off for keeping this design simple (a duplicate push is low-harm).
+                if (deferred.isSetOrExpired()) {
+                    return;
+                }
+                try {
+                    deferred.setResult(task.get());
+                }
+                catch (Exception e) {
+                    log.error("[{}] send task failed unexpectedly", name, e);
+                    deferred.setErrorResult(INTERNAL_SERVER_ERROR);
+                }
+            });
+        }
+        catch (RejectedExecutionException e) {
+            log.warn("[{}] worker pool saturated (queue full); rejecting with 503", name);
+            deferred.setResult(SERVICE_UNAVAILABLE);
+        }
+        return deferred;
+    }
+
+    /** @return the number of tasks currently waiting in the queue (for diagnostics/metrics). */
+    public int getQueueSize() {
+        return executor.getQueue().size();
+    }
+
+    /** @return the number of tasks currently being executed (for diagnostics/metrics). */
+    public int getActiveCount() {
+        return executor.getActiveCount();
+    }
+
+    /**
+     * Gracefully stops the worker pool: stops accepting new tasks, waits briefly for in-flight sends to finish,
+     * then forces termination. Intended to be called from the owning service's {@code @PreDestroy}.
+     */
+    public void shutdown() {
+        executor.shutdown();
+        try {
+            if (!executor.awaitTermination(10, TimeUnit.SECONDS)) {
+                executor.shutdownNow();
+            }
+        }
+        catch (InterruptedException e) {
+            executor.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private static ThreadFactory namedThreadFactory(String name) {
+        AtomicInteger counter = new AtomicInteger(1);
+        return runnable -> {
+            Thread thread = new Thread(runnable, name + "-sender-" + counter.getAndIncrement());
+            thread.setDaemon(true);
+            return thread;
+        };
+    }
+}

--- a/common/src/main/java/de/tum/cit/artemis/push/common/SendService.java
+++ b/common/src/main/java/de/tum/cit/artemis/push/common/SendService.java
@@ -1,10 +1,30 @@
 package de.tum.cit.artemis.push.common;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.context.request.async.DeferredResult;
 
+/**
+ * A service that relays push notifications to an external provider (APNs, Firebase, ...).
+ * <p>
+ * Sending is asynchronous: the implementation hands the work to a bounded worker pool and immediately
+ * returns a {@link DeferredResult}. This frees the Tomcat request thread right away, so that a slow or
+ * unreachable provider can never exhaust the servlet thread pool and starve the health endpoint.
+ */
 public interface SendService<T> {
 
-    ResponseEntity<Void> send(T request);
+    /**
+     * Accepts a send request and returns a {@link DeferredResult} that completes once the notification has
+     * been relayed (or rejected). The HTTP connection is held open until the deferred result is set or its
+     * safety timeout fires (then it completes with {@code 503 Service Unavailable}).
+     *
+     * @param request the notification(s) to send
+     * @return a deferred HTTP response (2xx on success, 4xx on a provider-side reject, 503 on saturation/timeout)
+     */
+    DeferredResult<ResponseEntity<Void>> send(T request);
 
+    /**
+     * @return the last known health of the connection to the external provider. Read from a cached flag only;
+     *         never performs network I/O, so it cannot be starved by a provider outage.
+     */
     boolean isHealthy();
 }

--- a/common/src/test/java/de/tum/cit/artemis/push/common/BoundedSendExecutorTest.java
+++ b/common/src/test/java/de/tum/cit/artemis/push/common/BoundedSendExecutorTest.java
@@ -1,0 +1,135 @@
+package de.tum.cit.artemis.push.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.context.request.async.DeferredResult;
+
+class BoundedSendExecutorTest {
+
+    private static final ResponseEntity<Void> OK = ResponseEntity.ok().build();
+
+    @Test
+    void completesDeferredResultWithTaskResult() throws InterruptedException {
+        BoundedSendExecutor executor = new BoundedSendExecutor("test", 2, 10, 60_000);
+        try {
+            DeferredResult<ResponseEntity<Void>> deferred = executor.submit(() -> OK);
+            awaitResult(deferred);
+            assertThat(deferred.getResult()).isEqualTo(OK);
+        }
+        finally {
+            executor.shutdown();
+        }
+    }
+
+    @Test
+    void rejectsWith503WhenWorkersAndQueueAreSaturated() throws InterruptedException {
+        // One worker, queue capacity one: the worker takes task A, task B fills the queue, task C must be rejected.
+        BoundedSendExecutor executor = new BoundedSendExecutor("test", 1, 1, 60_000);
+        CountDownLatch workerStarted = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        try {
+            executor.submit(() -> { // A: occupies the single worker
+                workerStarted.countDown();
+                awaitQuietly(release);
+                return OK;
+            });
+            assertThat(workerStarted.await(5, TimeUnit.SECONDS)).isTrue();
+
+            executor.submit(() -> OK); // B: fills the single queue slot
+
+            DeferredResult<ResponseEntity<Void>> rejected = executor.submit(() -> OK); // C: must be rejected immediately
+            assertThat(rejected.hasResult()).isTrue();
+            assertThat(((ResponseEntity<?>) rejected.getResult()).getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        }
+        finally {
+            release.countDown();
+            executor.shutdown();
+        }
+    }
+
+    @Test
+    void skipsTaskWhenDeferredResultAlreadyCompleted() throws InterruptedException {
+        // Simulates the safety timeout firing while the task waits in the queue: the worker must NOT run the task,
+        // to avoid sending a notification after the client already received a (timeout) response.
+        BoundedSendExecutor executor = new BoundedSendExecutor("test", 1, 10, 60_000);
+        CountDownLatch workerStarted = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        AtomicBoolean queuedTaskRan = new AtomicBoolean(false);
+        CountDownLatch followerDone = new CountDownLatch(1);
+        try {
+            executor.submit(() -> { // occupies the worker so the next submissions queue behind it
+                workerStarted.countDown();
+                awaitQuietly(release);
+                return OK;
+            });
+            assertThat(workerStarted.await(5, TimeUnit.SECONDS)).isTrue();
+
+            DeferredResult<ResponseEntity<Void>> queued = executor.submit(() -> {
+                queuedTaskRan.set(true);
+                return OK;
+            });
+            // Complete it as the timeout path would, while it is still waiting in the queue.
+            queued.setResult(ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).build());
+
+            // A follower task lets us deterministically wait until the worker has processed the queued task.
+            executor.submit(() -> {
+                followerDone.countDown();
+                return OK;
+            });
+
+            release.countDown();
+            assertThat(followerDone.await(5, TimeUnit.SECONDS)).isTrue();
+            assertThat(queuedTaskRan).isFalse();
+        }
+        finally {
+            release.countDown();
+            executor.shutdown();
+        }
+    }
+
+    @Test
+    void completesWith500WhenTaskThrows() throws InterruptedException {
+        BoundedSendExecutor executor = new BoundedSendExecutor("test", 1, 10, 60_000);
+        try {
+            DeferredResult<ResponseEntity<Void>> deferred = executor.submit(() -> {
+                throw new RuntimeException("boom");
+            });
+            awaitResult(deferred);
+            assertThat(((ResponseEntity<?>) deferred.getResult()).getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+        finally {
+            executor.shutdown();
+        }
+    }
+
+    @Test
+    void rejectsInvalidConfiguration() {
+        assertThrows(IllegalArgumentException.class, () -> new BoundedSendExecutor("test", 0, 10, 1000));
+        assertThrows(IllegalArgumentException.class, () -> new BoundedSendExecutor("test", 1, 0, 1000));
+    }
+
+    private static void awaitResult(DeferredResult<?> deferred) throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (!deferred.hasResult() && System.nanoTime() < deadline) {
+            Thread.sleep(5);
+        }
+        assertThat(deferred.hasResult()).isTrue();
+    }
+
+    private static void awaitQuietly(CountDownLatch latch) {
+        try {
+            latch.await(5, TimeUnit.SECONDS);
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/firebase/src/main/java/de/tum/cit/artemis/push/firebase/FirebaseSendService.java
+++ b/firebase/src/main/java/de/tum/cit/artemis/push/firebase/FirebaseSendService.java
@@ -3,30 +3,67 @@ package de.tum.cit.artemis.push.firebase;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.BatchResponse;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.MessagingErrorCode;
+import de.tum.cit.artemis.push.common.BoundedSendExecutor;
 import de.tum.cit.artemis.push.common.NotificationRequest;
 import de.tum.cit.artemis.push.common.SendService;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.context.request.async.DeferredResult;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
+/**
+ * Relays push notifications to Firebase Cloud Messaging (FCM) for Android devices.
+ *
+ * <p>Like {@link de.tum.cit.artemis.push.apns.ApnsSendService}, batches are sent on a {@link BoundedSendExecutor}
+ * (a fixed worker pool + bounded queue), never on the Tomcat request thread, so a slow or unreachable FCM cannot
+ * exhaust the servlet thread pool and starve the health endpoint. Health is a cached flag updated honestly by send
+ * outcomes; reading it never performs I/O.
+ */
 @Service
 public class FirebaseSendService implements SendService<List<NotificationRequest>> {
 
     private static final Logger log = LoggerFactory.getLogger(FirebaseSendService.class);
 
+    /** FCM's documented maximum number of messages per {@code sendEach} batch. */
+    private static final int MAX_BATCH_SIZE = 500;
+
+    /**
+     * FCM error codes that indicate a per-device problem (a bad/unregistered token), as opposed to a provider-side
+     * or credential problem. When an entire batch fails, the relay stays healthy ONLY if every failure carries one
+     * of these codes; any other code (including a null/unknown code) is treated as a provider failure, so the
+     * health check fails closed rather than masking an outage with unknown causes.
+     */
+    private static final Set<MessagingErrorCode> PER_DEVICE_ERROR_CODES = Set.of(MessagingErrorCode.UNREGISTERED, MessagingErrorCode.INVALID_ARGUMENT);
+
+    @Value("${firebase.workers:16}")
+    private int workers;
+
+    @Value("${firebase.queue-capacity:2000}")
+    private int queueCapacity;
+
+    @Value("${firebase.response-timeout-ms:30000}")
+    private long responseTimeoutMs;
+
     private final Optional<FirebaseApp> firebaseApp;
 
-    private boolean isConnected;
+    private volatile boolean isConnected;
+
+    private BoundedSendExecutor dispatcher;
 
     public FirebaseSendService() {
         this(loadDefaultFirebaseApp());
@@ -37,6 +74,11 @@ public class FirebaseSendService implements SendService<List<NotificationRequest
     FirebaseSendService(Optional<FirebaseApp> firebaseApp) {
         this.firebaseApp = firebaseApp;
         this.isConnected = firebaseApp.isPresent();
+    }
+
+    @PostConstruct
+    public void init() {
+        dispatcher = new BoundedSendExecutor("firebase", workers, queueCapacity, responseTimeoutMs);
     }
 
     private static Optional<FirebaseApp> loadDefaultFirebaseApp() {
@@ -55,46 +97,101 @@ public class FirebaseSendService implements SendService<List<NotificationRequest
     }
 
     @Override
-    public ResponseEntity<Void> send(List<NotificationRequest> requests) {
-        if (requests.size() > 500) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+    public DeferredResult<ResponseEntity<Void>> send(List<NotificationRequest> requests) {
+        if (requests.size() > MAX_BATCH_SIZE) {
+            return completed(ResponseEntity.status(HttpStatus.BAD_REQUEST).build());
+        }
+        // If the firebase app is not present, there is nothing to send; mirror the previous no-op success.
+        if (firebaseApp.isEmpty()) {
+            return completed(ResponseEntity.ok().build());
+        }
+        if (dispatcher == null) {
+            // Should not happen once the bean is initialized, but stay defensive rather than NPE.
+            return completed(ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).build());
+        }
+        return dispatcher.submit(() -> doSend(requests));
+    }
+
+    // visible for testing — performs the blocking batch send on a worker thread and maps the outcome to a response
+    ResponseEntity<Void> doSend(List<NotificationRequest> requests) {
+        List<Message> batch = requests
+                .stream()
+                .map((request) ->
+                        Message
+                                .builder()
+                                .putData("payload", request.payloadCipherText())
+                                .putData("iv", request.initializationVector())
+                                .setToken(request.token())
+                                .build()
+                )
+                .toList();
+
+        if (batch.isEmpty()) {
+            return ResponseEntity.ok().build();
         }
 
-        // If the firebase app is not present, we do not have to do anything
-        if (firebaseApp.isPresent()) {
-            List<Message> batch = requests
-                    .stream()
-                    .map((request) ->
-                            Message
-                                    .builder()
-                                    .putData("payload", request.payloadCipherText())
-                                    .putData("iv", request.initializationVector())
-                                    .setToken(request.token())
-                                    .build()
-                    )
-                    .toList();
-
-            try {
-                FirebaseMessaging.getInstance(firebaseApp.get()).sendEach(batch);
+        try {
+            BatchResponse response = FirebaseMessaging.getInstance(firebaseApp.orElseThrow()).sendEach(batch);
+            if (response.getSuccessCount() > 0) {
+                // At least one message was accepted — FCM is reachable and our credentials work. Any remaining
+                // failures in the batch are per-device (e.g. unregistered tokens) and do not make the relay unhealthy.
                 isConnected = true;
-            } catch (FirebaseMessagingException e) {
-                log.error("Failed to send push notifications via Firebase", e);
-                // In case the certificate is invalid, the THIRD_PARTY_AUTH_ERROR error code will be returned.
-                // Note: getMessagingErrorCode() can be null, so compare with == rather than List#contains,
-                // which throws a NullPointerException for null arguments on immutable lists.
-                if (e.getMessagingErrorCode() == MessagingErrorCode.THIRD_PARTY_AUTH_ERROR) {
-                    isConnected = false;
+                if (response.getFailureCount() > 0) {
+                    log.warn("Firebase batch completed with {} failed message(s) out of {}", response.getFailureCount(), batch.size());
                 }
-
-                return ResponseEntity.status(HttpStatus.EXPECTATION_FAILED).build();
+                return ResponseEntity.ok().build();
             }
+            // Nothing was accepted. Stay healthy only if EVERY failure is an explicit per-device problem (a bad
+            // device token); otherwise — a provider/credential outage, or unknown/null error codes — fail closed
+            // and report unhealthy + a retryable status, rather than masking an outage of unknown cause.
+            if (allFailuresArePerDevice(response)) {
+                isConnected = true;
+                log.warn("All {} Firebase message(s) failed with per-device errors (e.g. invalid/unregistered tokens)", response.getFailureCount());
+                return ResponseEntity.ok().build();
+            }
+            isConnected = false;
+            log.error("All {} Firebase message(s) failed (provider/credential or unknown error); marking Firebase unhealthy", response.getFailureCount());
+            return ResponseEntity.status(HttpStatus.EXPECTATION_FAILED).build();
+        } catch (FirebaseMessagingException e) {
+            // A thrown exception means the batch could not be sent at all (authentication / transport) — provider down.
+            isConnected = false;
+            log.error("Failed to send push notifications via Firebase (provider unreachable): {}", e.getMessagingErrorCode(), e);
+            return ResponseEntity.status(HttpStatus.EXPECTATION_FAILED).build();
         }
+    }
 
-        return ResponseEntity.ok().build();
+    /**
+     * @return true if EVERY failed message in the batch carries an explicit per-device error code. A failure with a
+     *         null/unknown code is not considered per-device, so this fails closed (treats it as a provider failure).
+     */
+    private static boolean allFailuresArePerDevice(BatchResponse response) {
+        return response.getResponses().stream()
+                .filter(sendResponse -> !sendResponse.isSuccessful())
+                .allMatch(sendResponse -> {
+                    FirebaseMessagingException exception = sendResponse.getException();
+                    MessagingErrorCode code = exception != null ? exception.getMessagingErrorCode() : null;
+                    return code != null && PER_DEVICE_ERROR_CODES.contains(code);
+                });
     }
 
     @Override
     public boolean isHealthy() {
         return isConnected;
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        if (dispatcher != null) {
+            dispatcher.shutdown();
+        }
+        // FirebaseApp.initializeApp registers a global default app; delete it so resources are released and a
+        // same-JVM restart does not fail with "FirebaseApp name [DEFAULT] already exists".
+        firebaseApp.ifPresent(FirebaseApp::delete);
+    }
+
+    private static DeferredResult<ResponseEntity<Void>> completed(ResponseEntity<Void> response) {
+        DeferredResult<ResponseEntity<Void>> deferred = new DeferredResult<>();
+        deferred.setResult(response);
+        return deferred;
     }
 }

--- a/firebase/src/test/java/de/tum/cit/artemis/push/firebase/FirebaseSendServiceTest.java
+++ b/firebase/src/test/java/de/tum/cit/artemis/push/firebase/FirebaseSendServiceTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.context.request.async.DeferredResult;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -56,7 +57,7 @@ class FirebaseSendServiceTest {
                 new NotificationRequest("iv-1", "cipher-1", "token-1", PushNotificationApiType.DEFAULT),
                 new NotificationRequest("iv-2", "cipher-2", "token-2", PushNotificationApiType.IOS_V2));
 
-        ResponseEntity<Void> response = service.send(requests);
+        ResponseEntity<Void> response = service.doSend(requests);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(service.isHealthy()).isTrue();
@@ -72,7 +73,7 @@ class FirebaseSendServiceTest {
         RecordingTransport transport = RecordingTransport.respondingWith(200, FCM_SUCCESS_BODY);
         FirebaseSendService service = serviceWith(transport);
 
-        ResponseEntity<Void> response = service.send(requests(501));
+        ResponseEntity<Void> response = body(service.send(requests(501)));
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
         assertThat(transport.urls).as("oversized batch must be rejected before any HTTP call").isEmpty();
@@ -89,7 +90,7 @@ class FirebaseSendServiceTest {
         RecordingTransport transport = RecordingTransport.respondingWith(401, authError);
         FirebaseSendService service = serviceWith(transport);
 
-        ResponseEntity<Void> response = service.send(requests(2));
+        ResponseEntity<Void> response = service.doSend(requests(2));
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.EXPECTATION_FAILED);
         assertThat(transport.urls).as("FCM should have been contacted for the batch").isNotEmpty();
@@ -99,7 +100,7 @@ class FirebaseSendServiceTest {
     void isANoOpWhenNoFirebaseCredentialsArePresent() {
         FirebaseSendService service = new FirebaseSendService(Optional.empty());
 
-        ResponseEntity<Void> response = service.send(requests(3));
+        ResponseEntity<Void> response = body(service.send(requests(3)));
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(service.isHealthy()).isFalse();
@@ -115,6 +116,13 @@ class FirebaseSendServiceTest {
                 .build();
         app = FirebaseApp.initializeApp(options, "fcm-test-" + APP_COUNTER.incrementAndGet());
         return new FirebaseSendService(Optional.of(app));
+    }
+
+    /** Extracts the response from a DeferredResult that the service completed synchronously (size/no-op paths). */
+    @SuppressWarnings("unchecked")
+    private static ResponseEntity<Void> body(DeferredResult<ResponseEntity<Void>> deferred) {
+        assertThat(deferred.hasResult()).as("deferred result should be completed synchronously").isTrue();
+        return (ResponseEntity<Void>) deferred.getResult();
     }
 
     private static List<NotificationRequest> requests(int count) {

--- a/hermes/src/main/java/de/tum/cit/artemis/push/RelayRestController.java
+++ b/hermes/src/main/java/de/tum/cit/artemis/push/RelayRestController.java
@@ -4,9 +4,13 @@ import de.tum.cit.artemis.push.apns.ApnsSendService;
 import de.tum.cit.artemis.push.common.NotificationRequest;
 import de.tum.cit.artemis.push.firebase.FirebaseSendPushNotificationsRequest;
 import de.tum.cit.artemis.push.firebase.FirebaseSendService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.request.async.DeferredResult;
 
 @RestController
 @RequestMapping("/api/push_notification")
@@ -21,13 +25,16 @@ public class RelayRestController {
         this.apnsSendService = apnsSendService;
     }
 
+    // Returns a DeferredResult so the Tomcat request thread is released immediately while the notification is
+    // relayed on a bounded worker pool. The HTTP connection stays open until the send completes or the safety
+    // timeout fires (then 503). This is what keeps a provider outage from starving the /api/health endpoint.
     @PostMapping("send_firebase")
-    public ResponseEntity<Void> send(@RequestBody FirebaseSendPushNotificationsRequest notificationRequests) {
+    public DeferredResult<ResponseEntity<Void>> send(@RequestBody FirebaseSendPushNotificationsRequest notificationRequests) {
         return firebaseSendService.send(notificationRequests.notificationRequest());
     }
 
     @PostMapping("send_apns")
-    public ResponseEntity<Void> send(@RequestBody NotificationRequest notificationRequest) {
+    public DeferredResult<ResponseEntity<Void>> send(@RequestBody NotificationRequest notificationRequest) {
         return apnsSendService.send(notificationRequest);
     }
 

--- a/hermes/src/main/resources/application.properties
+++ b/hermes/src/main/resources/application.properties
@@ -1,1 +1,36 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Push notification relay configuration
+#
+# Sends are handled asynchronously on a bounded worker pool per provider, so a slow or unreachable provider (most
+# importantly: an expired APNs certificate) can never exhaust the Tomcat request threads and starve /api/health.
+# All values below can be overridden via environment variables (e.g. apns.workers -> APNS_WORKERS).
+# ---------------------------------------------------------------------------------------------------------------------
 
+# --- APNs (Apple) ---
+# Number of worker threads == maximum number of concurrent APNs sends in flight.
+apns.workers=50
+# Maximum number of requests that may wait for a free worker before new requests are rejected with HTTP 503.
+apns.queue-capacity=2000
+# How long the HTTP connection is held open before the request completes with 503 (milliseconds).
+apns.response-timeout-ms=30000
+# TCP connection timeout for the pushy client (milliseconds).
+apns.connection-timeout-ms=2000
+# Note: the APNs certificate expiry is captured once at startup (from the certificate the client actually loads) and
+# compared against the clock on every health read, so an expired certificate is reported immediately and honestly.
+
+# --- Firebase (Android) ---
+# Number of worker threads == maximum number of concurrent FCM batch sends in flight.
+firebase.workers=16
+# Maximum number of batch requests that may wait for a free worker before new requests are rejected with HTTP 503.
+firebase.queue-capacity=2000
+# How long the HTTP connection is held open before the request completes with 503 (milliseconds).
+firebase.response-timeout-ms=30000
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Connection budget: each pending async request holds a Tomcat connection until it completes. The worst-case number
+# of pending requests is (workers + queue-capacity) per provider == ~4066 with the defaults above. We pin Tomcat's
+# max-connections explicitly (rather than relying on the framework default) so the health endpoint always has spare
+# connections and the starvation guarantee cannot be silently broken by a changed default. If the queue capacities
+# are raised substantially, raise this value to stay above (apns + firebase workers+queue) plus headroom.
+server.tomcat.max-connections=8192
+# ---------------------------------------------------------------------------------------------------------------------

--- a/hermes/src/test/java/de/tum/cit/artemis/push/RelayApplicationSmokeTest.java
+++ b/hermes/src/test/java/de/tum/cit/artemis/push/RelayApplicationSmokeTest.java
@@ -16,6 +16,8 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.web.context.request.async.DeferredResult;
 
 import java.util.List;
 
@@ -24,6 +26,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -76,13 +79,16 @@ class RelayApplicationSmokeTest {
 
     @Test
     void sendApnsDeserializesRequestAndDelegatesToApnsService() throws Exception {
-        when(apnsSendService.send(any())).thenReturn(ResponseEntity.ok().build());
+        when(apnsSendService.send(any())).thenReturn(deferred(HttpStatus.OK));
         String body = """
                 {"initializationVector":"iv","payloadCipherText":"cipher","token":"token-1","apiType":"IOS_V2"}""";
 
-        mockMvc.perform(post("/api/push_notification/send_apns")
+        // The endpoint returns a DeferredResult, so the response is produced via an async dispatch.
+        MvcResult mvcResult = mockMvc.perform(post("/api/push_notification/send_apns")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body))
+                .andReturn();
+        mockMvc.perform(asyncDispatch(mvcResult))
                 .andExpect(status().isOk());
 
         ArgumentCaptor<NotificationRequest> captor = ArgumentCaptor.forClass(NotificationRequest.class);
@@ -95,28 +101,32 @@ class RelayApplicationSmokeTest {
 
     @Test
     void sendApnsPropagatesServiceErrorStatus() throws Exception {
-        when(apnsSendService.send(any())).thenReturn(ResponseEntity.status(HttpStatus.EXPECTATION_FAILED).build());
+        when(apnsSendService.send(any())).thenReturn(deferred(HttpStatus.EXPECTATION_FAILED));
         String body = """
                 {"initializationVector":"iv","payloadCipherText":"cipher","token":"token","apiType":"DEFAULT"}""";
 
-        mockMvc.perform(post("/api/push_notification/send_apns")
+        MvcResult mvcResult = mockMvc.perform(post("/api/push_notification/send_apns")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body))
+                .andReturn();
+        mockMvc.perform(asyncDispatch(mvcResult))
                 .andExpect(status().isExpectationFailed());
     }
 
     @Test
     void sendFirebaseDeserializesBatchAndDelegatesToFirebaseService() throws Exception {
-        when(firebaseSendService.send(anyList())).thenReturn(ResponseEntity.ok().build());
+        when(firebaseSendService.send(anyList())).thenReturn(deferred(HttpStatus.OK));
         String body = """
                 {"notificationRequest":[
                   {"initializationVector":"iv1","payloadCipherText":"c1","token":"t1","apiType":"DEFAULT"},
                   {"initializationVector":"iv2","payloadCipherText":"c2","token":"t2","apiType":"IOS_V2"}
                 ]}""";
 
-        mockMvc.perform(post("/api/push_notification/send_firebase")
+        MvcResult mvcResult = mockMvc.perform(post("/api/push_notification/send_firebase")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body))
+                .andReturn();
+        mockMvc.perform(asyncDispatch(mvcResult))
                 .andExpect(status().isOk());
 
         @SuppressWarnings("unchecked")
@@ -125,5 +135,12 @@ class RelayApplicationSmokeTest {
         assertThat(captor.getValue()).hasSize(2);
         assertThat(captor.getValue().get(0).token()).isEqualTo("t1");
         assertThat(captor.getValue().get(1).apiType()).isEqualTo(PushNotificationApiType.IOS_V2);
+    }
+
+    /** Builds an already-completed DeferredResult, mirroring what the (now asynchronous) send services return. */
+    private static DeferredResult<ResponseEntity<Void>> deferred(HttpStatus status) {
+        DeferredResult<ResponseEntity<Void>> result = new DeferredResult<>();
+        result.setResult(ResponseEntity.status(status).build());
+        return result;
     }
 }


### PR DESCRIPTION
## Problem

When the APNs client certificate expires, pushy cannot establish a TLS connection. The relay sent notifications by calling `apnsClient.sendNotification(n).get()` (blocking, no timeout) **directly on the Tomcat request thread**, so every request thread blocked, `/api/health` (also a Tomcat thread) could no longer be served, and the endpoint hung ~10s — which cascades into the Artemis `HermesHealthIndicator` read timeout and slows `/management/health`. Health was also falsely optimistic: it only flipped to unhealthy on a `BadCertificate` *rejection*, but an expired **client** certificate fails the TLS handshake and surfaces as an `ExecutionException`, not a rejection, so the outage was never reflected.

## Solution

Make the two hard guarantees true: the health endpoint can never be starved, and nothing can build up without bound.

- **`BoundedSendExecutor`** (new, in `common`): a fixed worker pool + bounded `ArrayBlockingQueue` + `AbortPolicy`. The send endpoints now return a Spring MVC `DeferredResult`, so the Tomcat request thread is released immediately. Queue full → `503`; a `DeferredResult` safety timeout → `503`; the worker skips the send if the response was already completed (duplicate-send guard). Because a worker never starts a second provider call before its first returns, pushy's internal (unbounded) pending-acquisition queue is bounded by the worker count — no circuit breaker / epochs / client rebuild needed.
- **APNs honest health**: unhealthy on TLS/connection failures (`ExecutionException`) and credential-level rejections; ordinary per-device rejects (bad/unregistered token) stay healthy. A lightweight `ApnsCertificateInspector` captures the loaded certificate's expiry at startup, and `isHealthy()` gates on it in memory, so an expired certificate is reported **immediately** (no polling, no I/O on the health path). Adds a connection timeout. **Removes the plaintext certificate password log.**
- **Firebase honest health**: inspects the `sendEach` `BatchResponse`. A partially-successful batch stays healthy; an all-failed batch is healthy only if *every* failure is an explicit per-device code (`UNREGISTERED`/`INVALID_ARGUMENT`), otherwise it is unhealthy + `417` (fails closed on provider/credential/unknown errors). A thrown `FirebaseMessagingException` is unhealthy + `417`.
- `@PreDestroy` stops the executors, closes the APNs client and deletes the `FirebaseApp`.
- Pins `server.tomcat.max-connections` so the async backlog (≈4066 worst case) can never starve the health endpoint at the connector layer.
- `/api/health` keeps returning **HTTP 200** with the honest JSON body even when unhealthy (the Artemis consumer treats any non-2xx as an exception).

## Tests run

`./gradlew clean test` (Java 25) — green, 25 tests. New: `BoundedSendExecutorTest`, `ApnsCertificateInspectorTest`, APNs expired-certificate and TLS-handshake health tests. The existing `MockApnsServer` / Firebase `MockHttpTransport` / `@SpringBootTest` smoke tests were adapted to the async API.

## Notes

This was reviewed independently (cross-vendor) before opening. Deliberately keeps the design simple: if a pushy `.get()` ever wedged permanently, workers would be lost one by one and the relay would `503` (never affecting Tomcat/health) — an accepted trade-off, since the realistic failure modes (expired cert, normal outage) fail in bounded time.
