### PR TITLE
Fix deploy workflow SSH key secret name

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - name: Setup SSH
         env:
-          DEPLOYMENT_SSH_KEY: ${{ secrets.DEPLOYMENT_SSH_KEY }}
+          DEPLOYMENT_SSH_KEY: ${{ secrets.VM_SSH_KEY }}
           DEPLOYMENT_GATEWAY_SSH_KEY: ${{ secrets.DEPLOYMENT_GATEWAY_SSH_KEY }}
           DEPLOYMENT_GATEWAY_HOST: ${{ vars.DEPLOYMENT_GATEWAY_HOST }}
           DEPLOYMENT_GATEWAY_PORT: ${{ vars.DEPLOYMENT_GATEWAY_PORT }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,7 +86,7 @@ jobs:
           ansible-galaxy install -r requirements.yml --force
           ansible-galaxy install -r ~/.ansible/collections/ansible_collections/ls1intum/artemis/requirements.yml
 
-      - name: Deploy Artemis
+      - name: Deploy Hermes
         run: |
           # Select the playbook for the chosen environment
           if [ "${{ github.event.inputs.environment_name }}" = "production" ]; then


### PR DESCRIPTION
## Summary
- The `Setup SSH` step in `deploy.yml` referenced `secrets.DEPLOYMENT_SSH_KEY`, but the environment secret is actually named `VM_SSH_KEY` in both `staging` and `production`.
- The mismatch wrote an empty `~/.ssh/id_ed25519`, which surfaced as `Load key: error in libcrypto` and `Permission denied (publickey)` against `deployment@hermes-staging.artemis.cit.tum.de` (run [28039478279](https://github.com/ls1intum/Hermes/actions/runs/28039478279)).
- Aligns the workflow with the configured secret name so the staging/production deploys can authenticate.

## Test plan
- [ ] After merge, re-run `Deploy Hermes` against `staging` with `hermes_version=pr-34` and confirm the `Gathering Facts` task succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)